### PR TITLE
Add OrkasVideoStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ End-to-end systems that span understanding, editing, and generation under a sing
 - [video-db/Director](https://github.com/video-db/Director) — Open-source framework for building video agents that reason across search, edit, compile, and generate over a VideoDB backend. `code`
 - [HKUDS/ViMax](https://github.com/HKUDS/ViMax) — 12 specialized agents (director, screenwriter, producer, etc.) for end-to-end multi-shot video generation with RAG long-script design. `code`
 - [diffusionstudio/agent](https://github.com/diffusionstudio/agent) — Agentic video editing framework built on a browser-based WebCodecs compositing engine. `code`
+- [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) — Local-first CLI and MCP toolkit for agents to plan, compose, generate, and edit videos. `code`
 
 ## Multi-Agent Pipelines (Director / Writer / Editor)
 


### PR DESCRIPTION
## Summary

- add OrkasVideoStudio to All-in-One Agentic Frameworks
- identify its public CLI and MCP code release

## Checklist

- [x] One-line entry uses the required format
- [x] Canonical GitHub URL is live
- [x] Description is 87 characters and factual
- [x] Added to one section only

OrkasVideoStudio lets coding agents plan and execute multi-step video composition, generation, and editing workflows from editable plans.

Signed-off-by: BlueSkyID666 <84905354+BlueSkyID666@users.noreply.github.com>